### PR TITLE
fixed wine.debug() get

### DIFF
--- a/Functions/Engines/Wine/script.js
+++ b/Functions/Engines/Wine/script.js
@@ -43,7 +43,6 @@ Wine.prototype.wizard = function (wizard) {
 Wine.prototype.debug = function (debug) {
     // get
     if (arguments.length == 0) {
-        this._wineDebug = "";
         return this._wineDebug;
     }
 


### PR DESCRIPTION
Now, debug must be reset explicitly by calling `wine.debug("")`.

Fixes: fix: wine.debug() always returns empty string #82