### PR TITLE
removed .dll from DLL overrides

### DIFF
--- a/Functions/Engines/Wine/script.js
+++ b/Functions/Engines/Wine/script.js
@@ -640,6 +640,8 @@ var OverrideDLL = function () {
 
     that.set = function (mode, libraries) {
         libraries.forEach(function (library) {
+            // make sure library does not end with ".dll"
+            library = library.replace(".dll", "");
             that._regeditFileContent += "\"*" + library + "\"=\"" + mode + "\"\n";
         });
 

--- a/Functions/Verbs/crypt32/script.js
+++ b/Functions/Verbs/crypt32/script.js
@@ -5,6 +5,6 @@ Wine.prototype.crypt32 = function() {
     this.sp3extract("msasn1.dll");
 
     this.overrideDLL()
-        .set("native, builtin", ["crypt32.dll"])
+        .set("native, builtin", ["crypt32"])
         .do()
 };

--- a/Functions/Verbs/dotnet40/script.js
+++ b/Functions/Verbs/dotnet40/script.js
@@ -23,14 +23,14 @@ Wine.prototype.dotnet40 = function() {
     remove(this.system32directory() + "/mscoree.dll");
 
     this.overrideDLL()
-        .set("builtin", ["fusion.dll"])
+        .set("builtin", ["fusion"])
         .do();
 
     this.run(setupFile, [setupFile, "/q", "/c:\"install.exe /q\""])
         .wait("Please wait while {0} is installed ...".format(".NET Framework 4.0"));
 
     this.overrideDLL()
-        .set("native", ["mscoree.dll"])
+        .set("native", ["mscoree"])
         .do();
 
     this.run("reg", ["add", "HKLM\Software\Microsoft\NET Framework Setup\NDP\v4\Full", "/v", "Install", "/t", "REG_DWORD", "/d", "0001", "/f"])

--- a/Functions/Verbs/mfc42/script.js
+++ b/Functions/Verbs/mfc42/script.js
@@ -25,7 +25,7 @@ Wine.prototype.mfc42 = function() {
         .extract(['-F', 'mfc42*.dll']);
 
     this.overrideDLL()
-        .set("native, builtin", ["mfc42.dll", "mfc42u.dll"])
+        .set("native, builtin", ["mfc42", "mfc42u"])
         .do();
     return this;
 };

--- a/Functions/Verbs/vcrun2003/script.js
+++ b/Functions/Verbs/vcrun2003/script.js
@@ -15,8 +15,8 @@ Wine.prototype.vcrun2003 = function() {
         .wait("Please wait while {0} is installed ...".format("Microsoft Visual C++ 2003 Redistributable (x86)"));
 
     var dlls = [
-        "msvcp71.dll",
-        "mfc71.dll"
+        "msvcp71",
+        "mfc71"
     ];
     dlls.forEach(function (dll) {
         cp(wine.programFiles() + "/BZEdit1.6.5/" + dll, this.system32directory());

--- a/Functions/Verbs/vcrun2005/script.js
+++ b/Functions/Verbs/vcrun2005/script.js
@@ -14,11 +14,11 @@ Wine.prototype.vcrun2005 = function() {
         .wait("Please wait while {0} is installed ...".format("Microsoft Visual C++ 2005 Redistributable (x86)"));
 
     var dlls = [
-        "atl80.dll",
-        "msvcm80.dll",
-        "msvcp80.dll",
-        "msvcr80.dll",
-        "vcomp.dll"
+        "atl80",
+        "msvcm80",
+        "msvcp80",
+        "msvcr80",
+        "vcomp"
     ];
     this.overrideDLL()
         .set("native, builtin", dlls)

--- a/Functions/Verbs/vcrun2008/script.js
+++ b/Functions/Verbs/vcrun2008/script.js
@@ -26,11 +26,11 @@ Wine.prototype.vcrun2008 = function() {
     }
 
     var dlls = [
-        "atl90.dll",
-        "msvcm90.dll",
-        "msvcp90.dll",
-        "msvcr90.dll",
-        "vcomp90.dll",
+        "atl90",
+        "msvcm90",
+        "msvcp90",
+        "msvcr90",
+        "vcomp90",
     ];
     this.overrideDLL()
         .set("native, builtin", dlls)

--- a/Functions/Verbs/vcrun2010/script.js
+++ b/Functions/Verbs/vcrun2010/script.js
@@ -26,10 +26,10 @@ Wine.prototype.vcrun2010 = function() {
     }
 
     var dlls = [
-        "atl100.dll",
-        "msvcp100.dll",
-        "msvcr100.dll",
-        "vcomp100.dll",
+        "atl100",
+        "msvcp100",
+        "msvcr100",
+        "vcomp100",
     ];
     this.overrideDLL()
         .set("native, builtin", dlls)

--- a/Functions/Verbs/vcrun2012/script.js
+++ b/Functions/Verbs/vcrun2012/script.js
@@ -26,10 +26,10 @@ Wine.prototype.vcrun2012 = function() {
     }
 
     var dlls = [
-        "atl110.dll",
-        "msvcp110.dll",
-        "msvcr110.dll",
-        "vcomp110.dll"
+        "atl110",
+        "msvcp110",
+        "msvcr110",
+        "vcomp110"
     ];
     this.overrideDLL()
         .set("native, builtin", dlls)

--- a/Functions/Verbs/vcrun2013/script.js
+++ b/Functions/Verbs/vcrun2013/script.js
@@ -26,7 +26,7 @@ Wine.prototype.vcrun2013 = function() {
     }
 
     this.overrideDLL()
-        .set("native, builtin", ["atl120.dll", "msvcp120.dll", "msvcr120.dll", "vcomp120.dll"])
+        .set("native, builtin", ["atl120", "msvcp120", "msvcr120", "vcomp120"])
         .do();
 
     return this;

--- a/Functions/Verbs/vcrun2015/script.js
+++ b/Functions/Verbs/vcrun2015/script.js
@@ -26,18 +26,18 @@ Wine.prototype.vcrun2015 = function() {
     }
 
     var dlls = [
-        "api-ms-win-crt-conio-l1-1-0.dll",
-        "api-ms-win-crt-heap-l1-1-0.dll",
-        "api-ms-win-crt-locale-l1-1-0.dll",
-        "api-ms-win-crt-math-l1-1-0.dll",
-        "api-ms-win-crt-runtime-l1-1-0.dll",
-        "api-ms-win-crt-stdio-l1-1-0.dll",
-        "atl140.dll",
-        "msvcp140.dll",
-        "msvcr140.dll",
-        "ucrtbase.dll",
-        "vcomp140.dll",
-        "vcruntime140.dll"
+        "api-ms-win-crt-conio-l1-1-0",
+        "api-ms-win-crt-heap-l1-1-0",
+        "api-ms-win-crt-locale-l1-1-0",
+        "api-ms-win-crt-math-l1-1-0",
+        "api-ms-win-crt-runtime-l1-1-0",
+        "api-ms-win-crt-stdio-l1-1-0",
+        "atl140",
+        "msvcp140",
+        "msvcr140",
+        "ucrtbase",
+        "vcomp140",
+        "vcruntime140"
     ];
     this.overrideDLL()
         .set("native, builtin", dlls)

--- a/Games/Age of Empires III: Complete Collection/Steam/script.js
+++ b/Games/Age of Empires III: Complete Collection/Steam/script.js
@@ -9,7 +9,7 @@ new SteamScript()
     .postInstall(function(wine, wizard) {
         wine.mfc42();
         wine.overrideDLL()
-            .set("native, builtin", ["pidgen.dll"])
+            .set("native, builtin", ["pidgen"])
             .do();
     })
     .go();


### PR DESCRIPTION
As pointed out by @feanor12 in #168, DLL overrides may not have the suffix .dll. This PR removes .dll from the existing DLL overrides and makes the DLL override function more robust by removing .dll from the input parameters.

fixes #153