### PR TITLE
fixed Uplay

### DIFF
--- a/Games/Uplay/Online/script.js
+++ b/Games/Uplay/Online/script.js
@@ -8,7 +8,8 @@ new OnlineInstallerScript()
     .url("https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UplayInstaller.exe")
     .category("Games")
     .executable("UbisoftGameLauncher.exe")
-    .wineVersion("2.1")
+    .wineVersion("2.5")
+    .wineDistribution("staging")
     .preInstall(function(wine, wizard) {
         wine.windowsVersion("vista");
     })


### PR DESCRIPTION
I also had to run
```
sudo cp /usr/lib/i386-linux-gnu/libgnutls.so.30 /usr/lib/i386-linux-gnu/libgnutls.so.26
```
to fix
```
err:winediag:schan_imp_init Failed to load libgnutls, secure connections will not be available.
```

Not sure if we can do anything in Phoenicis to fix that error automatically. @qparis any idea?
See also [Wine bug 38466](https://bugs.winehq.org/show_bug.cgi?id=38466)