### PR TITLE
added verb for Uplay

### DIFF
--- a/Functions/Verbs/uplay/script.js
+++ b/Functions/Verbs/uplay/script.js
@@ -1,0 +1,16 @@
+include(["Functions", "Engines", "Wine"]);
+
+Wine.prototype.uplay = function() {
+    var setupFile = new Resource()
+        .wizard(this._wizard)
+        .url("https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UplayInstaller.exe")
+        .name("UplayInstaller.exe")
+        .get();
+
+    this.run(setupFile)
+        .wait("Please follow the steps of the Uplay setup.\n\nUncheck \"Run Uplay\" or close Uplay completely after the setup so that the installation can continue.");
+
+    this.setOsForApplication().set("upc.exe", "winxp").do();
+
+    return this;
+};


### PR DESCRIPTION
Some games require Steam and Uplay and do not provide Uplay automatically. I believe that installing Uplay as a verb is the cleanest solution for this (e.g. compared to a new SteamUplayScript).