### PR TITLE
Warcraft 3 TFT preinstall check

### DIFF
--- a/Games/Warcraft III TFT/Online/script.js
+++ b/Games/Warcraft III TFT/Online/script.js
@@ -9,6 +9,8 @@ new OnlineInstallerScript()
     .category("Games")
     .executable("Frozen Throne.exe")
     .preInstall(function (wine, wizard) {
-        wizard.message("Please install Warcraft III before installing The Frozen Throne.");
+        if (!fileExists(wine.prefixDirectory + "drive_c/" + wine.programFiles() + "/Warcraft III/Warcraft III.exe")) {
+            wizard.message("Please install Warcraft III before installing The Frozen Throne.");
+        }
     })
     .go();

--- a/Games/Warcraft III TFT/Online/script.js
+++ b/Games/Warcraft III TFT/Online/script.js
@@ -8,9 +8,7 @@ new OnlineInstallerScript()
     .url("https://www.battle.net/download/getLegacy?product=W3XP&locale=en-US&os=WIN")
     .category("Games")
     .executable("Frozen Throne.exe")
-    .preInstall(function(wine, wizard) {
-    if (!fileExists(wine.prefixDirectory + "drive_c/" + wine.programFiles() + "/Warcraft III/Warcraft III.exe")) {
+    .preInstall(function (wine, wizard) {
         wizard.message("Please install Warcraft III before installing The Frozen Throne.");
-    }
-})
+    })
     .go();

--- a/Games/Warcraft III TFT/Online/script.js
+++ b/Games/Warcraft III TFT/Online/script.js
@@ -8,4 +8,9 @@ new OnlineInstallerScript()
     .url("https://www.battle.net/download/getLegacy?product=W3XP&locale=en-US&os=WIN")
     .category("Games")
     .executable("Frozen Throne.exe")
+    .preInstall(function(wine, wizard) {
+    if (!fileExists(wine.prefixDirectory + "drive_c/" + wine.programFiles() + "/Warcraft III/Warcraft III.exe")) {
+        wizard.message("Please install Warcraft III before installing The Frozen Throne.");
+    }
+})
     .go();


### PR DESCRIPTION
Check and warn if Warcraft III base game is not installed while installing Warcraft III TFT.