### PR TITLE
translation via "tr" example

### DIFF
--- a/Functions/QuickScript/InstallerScript/script.js
+++ b/Functions/QuickScript/InstallerScript/script.js
@@ -20,7 +20,7 @@ InstallerScript.prototype.go = function() {
 
     // if no name given, ask user
     if (this._name == "Custom Installer") {
-        this._name = setupWizard.textbox("Please enter the name of your application.");
+        this._name = setupWizard.textbox(tr("Please enter the name of your application."));
     }
 
     setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);

--- a/i18n/Messages_de.properties
+++ b/i18n/Messages_de.properties
@@ -1,0 +1,1 @@
+Please\ enter\ the\ name\ of\ your\ application.=Bitte\ geben\ Sie\ einen\ Namen\ f\u00fcr\ Ihre\ Anwendung ein.

--- a/i18n/Messages_de.properties
+++ b/i18n/Messages_de.properties
@@ -1,1 +1,10 @@
-Please\ enter\ the\ name\ of\ your\ application.=Bitte\ geben\ Sie\ einen\ Namen\ f\u00fcr\ Ihre\ Anwendung ein.
+# German translations for PACKAGE package
+# German translation for PACKAGE.
+# Copyright (C) 2017 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Plata <plata@phoenicis.org>, 2017.
+#
+!=Project-Id-Version\: \nReport-Msgid-Bugs-To\: \nPOT-Creation-Date\: 2017-06-09 22\:34+0200\nPO-Revision-Date\: 2017-06-09 22\:41+0200\nLast-Translator\: Plata <plata@phoenicis.org>\nLanguage-Team\: German\nLanguage\: de\nMIME-Version\: 1.0\nContent-Type\: text/plain; charset\=UTF-8\nContent-Transfer-Encoding\: 8bit\nPlural-Forms\: nplurals\=2; plural\=(n \!\= 1);\nX-Generator\: Poedit 1.8.7.1\n
+
+#: Functions/QuickScript/InstallerScript/script.js:23
+Please\ enter\ the\ name\ of\ your\ application.=Bitte geben Sie einen Namen f\u00fcr Ihre Anwendung ein.

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -1,0 +1,24 @@
+# German translations for PACKAGE package
+# German translation for PACKAGE.
+# Copyright (C) 2017 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Plata <plata@phoenicis.org>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-09 22:34+0200\n"
+"PO-Revision-Date: 2017-06-09 22:41+0200\n"
+"Last-Translator: Plata <plata@phoenicis.org>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#: Functions/QuickScript/InstallerScript/script.js:23
+msgid "Please enter the name of your application."
+msgstr "Bitte geben Sie einen Namen für Ihre Anwendung ein."

--- a/i18n/keys.pot
+++ b/i18n/keys.pot
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-09 22:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Functions/QuickScript/InstallerScript/script.js:23
+msgid "Please enter the name of your application."
+msgstr ""


### PR DESCRIPTION
requires PlayOnLinux/POL-POM-5#881

Steps:
* Generate the `.pot`:
    ```bash
    find . -iname "*.js" | xargs -d '\n' xgettext --from-code=UTF-8 --language=Javascript -ktr -o i18n/keys.pot
    ```
* Create a `.po`:
    ```bash
    msginit -i i18n/keys.pot -o i18n/de.po
    ```
* Translate
* Generate `.properties`
    ```bash
    msgcat --properties-output i18n/de.po -o i18n/Messages_de.properties
    ```